### PR TITLE
MFLOW-4 Add checks:write permission for Firebase action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read
       deployments: write
+      checks: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
- Add checks: write permission for Firebase deployment action
- Resolves 'Resource not accessible by integration' error from Firebase action
- Firebase action needs this permission to create check runs for deployment status

Required permissions:
- contents: read (repository access)
- deployments: write (deployment API)
- checks: write (check runs for Firebase action)

🤖 Generated with [Claude Code](https://claude.ai/code)