### PR TITLE
MFLOW-4 Fix CI build issues: ESLint and Babel warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@types/d3": "^7.4.3",
         "@types/d3-sankey": "^0.12.4",
         "tailwindcss": "^3.4.1"
@@ -834,9 +835,18 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -2094,6 +2104,18 @@
         "core-js-compat": "^3.31.0",
         "semver": "^6.3.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     ]
   },
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@types/d3": "^7.4.3",
     "@types/d3-sankey": "^0.12.4",
     "tailwindcss": "^3.4.1"

--- a/src/pages/budget/index.tsx
+++ b/src/pages/budget/index.tsx
@@ -20,7 +20,7 @@ const BudgetPage: FC = () => {
         description: '',
         autoGenerateCategories: true
     });
-    const [autoSetupOptions, setAutoSetupOptions] = useState({
+    const [autoSetupOptions, _setAutoSetupOptions] = useState({
         monthsToAnalyze: 6,
         bufferPercentage: 20,
         includeSmallCategories: false


### PR DESCRIPTION
- Fix ESLint error: prefix unused setAutoSetupOptions with underscore
- Add @babel/plugin-proposal-private-property-in-object to devDependencies
- Resolves CI build failures due to warnings being treated as errors

Changes:
- src/pages/budget/index.tsx: _setAutoSetupOptions to silence ESLint warning
- package.json: Added Babel plugin for private property support

Build now completes successfully in CI environment.

🤖 Generated with [Claude Code](https://claude.ai/code)